### PR TITLE
#29 BonetTetT: lagged-J̄ + FD tangent — quadratic Newton on moderate κ

### DIFF
--- a/benchmark_XML/level.5/README.md
+++ b/benchmark_XML/level.5/README.md
@@ -128,15 +128,27 @@ the explicit benchmarks above.
 | File | Element | Material | Notes |
 |------|---------|----------|-------|
 | `tet4_hyperelastic.xml` | `<updated_lagrangian>` Tet4 | Neo-Hookean | Quasi-static stretch, classic Tet4 |
-| `tet4_hyperelastic_anp.xml` | `<bonet_tet>` Tet4 | Neo-Hookean | Same with ANP F-bar (issue #28) |
-| `compress_tet4.xml` | Plain Tet4 | Near-incompressible NH | Tet4 locks (κ = 1000, μ = 1) |
-| `compress_bonet_tet.xml` | BonetTet | Same NH | ANP residual / inherited tangent inconsistency → issue #29 |
+| `tet4_hyperelastic_anp.xml` | `<bonet_tet>` Tet4 | Neo-Hookean (κ=100, μ=40) | ANP F-bar with lagged-J̄ + FD tangent (#29) — quadratic Newton, ~1 iter/step |
+| `compress_tet4.xml` | Plain Tet4 | Near-incompressible NH (κ=1000, μ=1) | Tet4 locks |
+| `compress_bonet_tet.xml` | BonetTet | Same NH | Diverges (severe near-incompressibility, see limitation below) |
 
-> **Known limitation (BonetTetT, classic implicit only)**: the ANP
-> residual uses F̄ but the analytical tangent inherited from
-> `UpdatedLagrangianT` is computed from F.  Newton stalls under
-> near-incompressibility — fix is numerical tangent (forward
-> differences of `FormKd`), tracked in issue #29.
+> **#29 status — partial improvement landed.** The lagged-J̄ scheme
+> caches J̄ at step start and a per-element forward-FD `FormStiffness`
+> builds the tangent from the F̄ residual at frozen J̄.  On moderately
+> near-incompressible cases (κ/μ ~ 2.5, `tet4_hyperelastic_anp.xml`)
+> Newton now converges quadratically in ~1 iter/step — a 15× iteration
+> reduction vs the linear-rate baseline that needed ~16 iter/step.
+>
+> **Remaining limitation**: the per-element 12×12 FD tangent cannot
+> express the cross-element ∂J̄/∂u coupling (J̄ is nodal-averaged, so a
+> node perturbation changes J̄ in every neighbouring element).  At
+> severe near-incompressibility (κ ≫ μ, e.g. `compress_bonet_tet.xml`
+> with κ=1000, μ=1) the missing block kills the local volumetric
+> stiffness and Newton diverges.  Bonet & Burton 1998 itself only
+> formulates the *residual* — for explicit dynamics — and never derives
+> an implicit tangent; a fully consistent tangent would follow
+> Bonet/Marriott/Hassan 2001 or Caylak/Mahnken 2012, kept open as a
+> future analytical-tangent extension of #29.
 
 ## Coverage matrix
 

--- a/tahoe/src/elements/continuum/solid/BonetTetT.cpp
+++ b/tahoe/src/elements/continuum/solid/BonetTetT.cpp
@@ -6,6 +6,7 @@
 #include "ModelManagerT.h"
 #include "FiniteStrainT.h"
 #include "ElementCardT.h"
+#include "ShapeFunctionT.h"
 #include "iArrayT.h"
 #include "dArray2DT.h"
 #include "dMatrixT.h"
@@ -52,6 +53,12 @@ void BonetTetT::TakeParameterList(const ParameterListT& list)
 	BuildANPData();
 	std::cout << "BonetTetT: ANP-Tet4 (LS-DYNA ELFORM=13) active for "
 	          << fNelem << " tets" << std::endl;
+
+	/* Populate J̄_e from the reference coordinates so the very first
+	 * FormRHS (which can fire before the first InitStep depending on
+	 * the time-stepping driver) sees a sane J̄ = 1.0 across the mesh
+	 * — F̄ = F at undeformed, no spurious volumetric scaling. */
+	UpdateJBar();
 }
 
 /* Build flat connectivity, reference volumes, and instantiate ANP helper. */
@@ -138,24 +145,145 @@ void BonetTetT::SetGlobalShape(void)
 	}
 }
 
-/* RHS pre-pass: compute J_e for every element, run the ANP helper, then
- * dispatch to the inherited element loop (which calls our SetGlobalShape). */
+/* Wrapper used by InitStep — and by TakeParameterList for the very first
+ * residual evaluation, before InitStep has been called by the time loop. */
+void BonetTetT::UpdateJBar(void)
+{
+	if (!fANP) return;
+	ComputeAllJe();
+	fANP->ComputeJBar(fJe, fJbarE);
+}
+
+/* Step-start hook: compute J̄_e from the current (start-of-step)
+ * coordinates and cache it in fJbarE.  RHSDriver / LHSDriver read this
+ * frozen value during every Newton iteration of the step, making the
+ * FD tangent (which also reads fJbarE) consistent with the residual
+ * — quadratic convergence on moderately near-incompressible cases (#29). */
+void BonetTetT::InitStep(void)
+{
+	UpdatedLagrangianT::InitStep();
+	UpdateJBar();
+}
+
+/* RHS / LHS: the lagged-J̄ scheme (#29) — J̄ is computed once at step
+ * start by InitStep and held frozen for every Newton iteration of the
+ * step.  Both residual and FD tangent see the same J̄, so the local
+ * tangent is the consistent ∂R(u; J̄_step)/∂u and Newton converges
+ * quadratically.  The trade-off is that the converged solution
+ * satisfies R(u; J̄_step-start) = 0, not R(u; J̄(u)) = 0; the lag is
+ * absorbed across time steps. */
 void BonetTetT::RHSDriver(void)
 {
-	if (fANP) {
-		ComputeAllJe();
-		fANP->ComputeJBar(fJe, fJbarE);
-	}
 	UpdatedLagrangianT::RHSDriver();
 }
 
-/* Same pre-pass for the stiffness assembly so the numerical / analytical
- * tangent uses the same F_bar that the residual was based on. */
 void BonetTetT::LHSDriver(GlobalT::SystemTypeT sys_type)
 {
-	if (fANP) {
-		ComputeAllJe();
-		fANP->ComputeJBar(fJe, fJbarE);
-	}
 	UpdatedLagrangianT::LHSDriver(sys_type);
+}
+
+/* Refresh F + F-bar from the perturbed fLocDisp / fLocCurrCoords without
+ * reloading them from the global Field.  Mirrors SimoQ1P0::
+ * RecomputeDeformationState — SolidElementT::SetGlobalShape would call
+ * SetLocalU(fLocDisp), clobbering the FD perturbation. */
+void BonetTetT::RecomputeF(void)
+{
+	const int nip = NumIP();
+	const int elem = CurrElementNumber();
+
+	/* current-config shape function derivatives (read fLocCurrCoords) */
+	fCurrShapes->SetDerivatives();
+
+	/* F = I + grad u, computed via reference-config shapes */
+	for (int ip = 0; ip < nip; ip++) {
+		dMatrixT& F = fF_List[ip];
+		fShapes->GradU(fLocDisp, F, ip);
+		F.PlusIdentity();
+	}
+
+	/* F-bar scaling with the FROZEN J̄_e cached by InitStep */
+	if (fANP && elem >= 0 && elem < fNelem) {
+		double Jb = fJbarE[elem];
+		for (int ip = 0; ip < nip; ip++) {
+			dMatrixT& F = fF_List[ip];
+			double J = F.Det();
+			if (J <= 0.0) continue;
+			double scale = std::cbrt(Jb / J);
+			double* p = F.Pointer();
+			for (int k = 0; k < 9; k++) p[k] *= scale;
+		}
+	}
+}
+
+/* Element internal force into a caller-provided buffer (writes, does not
+ * accumulate).  Same physics as the inherited UpdatedLagrangianT::FormKd:
+ * integrates B^T · σ over IPs, with σ from the F-bar in fF_List. */
+void BonetTetT::ComputeInternalForce(double constK, dArrayT& force)
+{
+	const int n = fRHS.Length();
+	dArrayT fRHS_save(n);
+	for (int i = 0; i < n; i++) fRHS_save[i] = fRHS[i];
+
+	fRHS = 0.0;
+	UpdatedLagrangianT::FormKd(constK);
+	for (int i = 0; i < n; i++) force[i] = fRHS[i];
+
+	for (int i = 0; i < n; i++) fRHS[i] = fRHS_save[i];
+}
+
+/* Numerical (forward-FD) tangent of the F-bar residual at frozen J̄ —
+ * the lagged-J̄ scheme's consistent tangent.  See header for the
+ * derivation rationale.  Per-element, no cross-element terms. */
+void BonetTetT::FormStiffness(double constK)
+{
+	if (!fANP) {                           /* fall back if not Tet4 */
+		UpdatedLagrangianT::FormStiffness(constK);
+		return;
+	}
+
+	const int nsd = NumSD();
+	const int nen = NumElementNodes();
+	const int ndof_elem = nen * nsd;
+	const int nip = NumIP();
+	const double eps = 1.0e-6;
+
+	/* save state (the inner FD perturbs fLocDisp / fLocCurrCoords / fF_List) */
+	dArrayT u_save(fLocDisp.Length());
+	for (int k = 0; k < fLocDisp.Length(); k++) u_save[k] = fLocDisp[k];
+	dArrayT x_save(fLocCurrCoords.Length());
+	for (int k = 0; k < fLocCurrCoords.Length(); k++) x_save[k] = fLocCurrCoords[k];
+	ArrayT<dMatrixT> F_save(nip);
+	for (int ip = 0; ip < nip; ip++) {
+		F_save[ip].Dimension(nsd, nsd);
+		F_save[ip] = fF_List[ip];
+	}
+
+	/* baseline residual at the unperturbed state (uses cached F-bar in fF_List) */
+	dArrayT f0(ndof_elem);
+	ComputeInternalForce(constK, f0);
+
+	/* column-by-column FD */
+	dArrayT f_pert(ndof_elem);
+	fLHS = 0.0;
+	for (int a = 0; a < nen; a++) {
+		for (int i = 0; i < nsd; i++) {
+			fLocDisp(a, i)       += eps;
+			fLocCurrCoords(a, i) += eps;
+			RecomputeF();
+			ComputeInternalForce(constK, f_pert);
+
+			const int col = a * nsd + i;
+			for (int j = 0; j < ndof_elem; j++)
+				fLHS(j, col) += (f_pert[j] - f0[j]) / eps;
+
+			fLocDisp(a, i)       -= eps;
+			fLocCurrCoords(a, i) -= eps;
+		}
+	}
+
+	/* restore state */
+	for (int k = 0; k < fLocDisp.Length(); k++) fLocDisp[k] = u_save[k];
+	for (int k = 0; k < fLocCurrCoords.Length(); k++) fLocCurrCoords[k] = x_save[k];
+	for (int ip = 0; ip < nip; ip++) fF_List[ip] = F_save[ip];
+	fCurrShapes->SetDerivatives();
 }

--- a/tahoe/src/elements/continuum/solid/BonetTetT.h
+++ b/tahoe/src/elements/continuum/solid/BonetTetT.h
@@ -8,17 +8,37 @@
  * integrator-agnostic; this element drives it from inside the Newton
  * iteration of the implicit / quasistatic solver.
  *
- * Algorithm per Newton iteration:
- *   1. Pre-pass: loop over all elements, compute J_e = V_curr/V_ref
- *      (cheap closed-form for Tet4 from current and reference coords)
- *   2. ANP helper: J_n = sum V_e^ref J_e / sum V_e^ref, J_bar_e = avg of J_n
- *   3. Standard FormKd loop: SetGlobalShape() computes F per element;
- *      THIS class's override scales F to F_bar = (J_bar/J)^(1/3) F
- *      before the material is called.
+ * Algorithm per step (issue #29: lagged-J̄ + FD tangent):
+ *   1. Step-start (InitStep): compute J_e = V_curr/V_ref from the current
+ *      (start-of-step) coordinates, run the ANP helper to get J̄_e at
+ *      every element.  Cache J̄_e in fJbarE.
+ *   2. Inside Newton (RHSDriver / LHSDriver): use the cached J̄_e —
+ *      do NOT update it during the inner iteration.  SetGlobalShape()
+ *      computes F per element from current u; this override scales F to
+ *      F̄ = (J̄_e / J)^(1/3) F using the cached J̄_e.
+ *   3. FormStiffness builds the per-element 12×12 tangent by forward
+ *      finite differences on the F̄ residual at frozen J̄ (RecomputeF +
+ *      ComputeInternalForce per perturbation).  Both residual and tangent
+ *      see the same fJbarE, so the local tangent IS the consistent
+ *      ∂R(u; J̄_step-start)/∂u — quadratic Newton convergence on
+ *      moderately near-incompressible cases.
  *
- * The numerical stiffness tangent (used by SimoQ1P0) gives quadratic Newton
- * convergence for this kind of F-bar element; a future analytical tangent
- * would be cheaper but not required for correctness.
+ * Trade-offs / limitations:
+ *   - The converged solution satisfies R(u; J̄_step-start) = 0, not the
+ *     fully-coupled R(u; J̄(u)) = 0.  For quasi-static with small load
+ *     steps the lag is small; the residual at the next InitStep absorbs
+ *     it as J̄ is refreshed.
+ *   - The per-element FD tangent misses the cross-element ∂J̄/∂u
+ *     coupling (J̄ is nodal-averaged, so a node perturbation changes J̄
+ *     in every neighbouring element — that block can't fit in a 12×12
+ *     element-local stiffness).  For SEVERELY near-incompressible
+ *     problems (κ ≫ μ, e.g. compress_bonet_tet.xml with κ=1000, μ=1)
+ *     this missing volumetric coupling makes the local tangent's bulk
+ *     stiffness vanish and Newton diverges.  Bonet & Burton 1998 itself
+ *     formulates only the residual — for explicit dynamics — and never
+ *     derives an implicit tangent; a fully consistent tangent would
+ *     follow Bonet/Marriott/Hassan 2001 or Caylak/Mahnken 2012, tracked
+ *     as a future analytical-tangent extension.
  *
  * XML usage (drop-in replacement for <updated_lagrangian> when using tets):
  *   <bonet_tet field_name="displacement">
@@ -53,29 +73,55 @@ public:
 	virtual void TakeParameterList(const ParameterListT& list);
 	/*@}*/
 
+	/** Override: at step start, compute J̄_e from current coordinates and
+	 *  cache it for the inner Newton iteration (issue #29 lagged-J̄). */
+	virtual void InitStep(void);
+
 protected:
 
 	/** Override: standard F + then F-bar correction (in-place on fF_List). */
 	virtual void SetGlobalShape(void);
 
-	/** Override: pre-pass to compute J_e and J_bar_e for all elements,
-	 *  then dispatch to UpdatedLagrangianT::RHSDriver which iterates and
-	 *  calls our overridden SetGlobalShape per element. */
+	/** Override: dispatch to UpdatedLagrangianT::RHSDriver which iterates
+	 *  elements and calls our overridden SetGlobalShape (which uses the
+	 *  step-start J̄_e cached by InitStep). */
 	virtual void RHSDriver(void);
 
-	/** Override: same pre-pass, then UpdatedLagrangianT::LHSDriver. */
+	/** Override: same as RHSDriver — uses the cached J̄_e from InitStep,
+	 *  so the inherited F-based analytical tangent is consistent with
+	 *  the residual ∂R/∂u at frozen J̄. */
 	virtual void LHSDriver(GlobalT::SystemTypeT sys_type);
+
+	/** Override: numerical (forward-FD) tangent of the F-bar residual at
+	 *  the cached (frozen) J̄.  Per-element 12×12 block, FD on 12 dofs.
+	 *  With both residual and tangent reading the same fJbarE, the local
+	 *  tangent is the consistent ∂R(u; J̄_step-start)/∂u — quadratic Newton
+	 *  convergence on moderately incompressible cases.
+	 *
+	 *  Limitation: the cross-element ∂J̄/∂u coupling (a node perturbation
+	 *  changes J̄ in every neighbouring element) cannot fit in a 12×12
+	 *  block.  At severe near-incompressibility (κ ≫ μ) the missing
+	 *  block kills the local volumetric stiffness and Newton diverges.
+	 *  See header docstring for the future analytical-tangent path. */
+	virtual void FormStiffness(double constK);
 
 private:
 
-	void BuildANPData(void);   /* allocates fVrefE, fFlatConn, ANP helper */
-	void ComputeAllJe(void);   /* fills fJe in current configuration */
+	void BuildANPData(void);            /* allocates fVrefE, fFlatConn, ANP helper */
+	void ComputeAllJe(void);            /* fills fJe in current configuration */
+	void UpdateJBar(void);              /* ComputeAllJe + fANP->ComputeJBar */
+	void ComputeInternalForce(double constK, dArrayT& force);
+	void RecomputeF(void);              /* refresh F + F-bar from current
+	                                     * fLocDisp / fLocCurrCoords WITHOUT
+	                                     * reloading them from the global
+	                                     * Field — for FD perturbation. */
 
 	ANPHelperT* fANP;
 	int*        fFlatConn;     /* [fNelem * 4] connectivity, 0-based */
 	double*     fVrefE;        /* [fNelem] reference tet volume */
-	double*     fJe;           /* [fNelem] J = V_cur/V_ref each Newton iter */
-	double*     fJbarE;        /* [fNelem] nodal-averaged J */
+	double*     fJe;           /* [fNelem] J = V_cur/V_ref */
+	double*     fJbarE;        /* [fNelem] nodal-averaged J — CACHED across
+	                            * Newton iters of one step (#29) */
 	int         fNelem;
 };
 


### PR DESCRIPTION
## Summary
- New lagged-J̄ scheme for ANP-Tet4: `InitStep` caches `J̄_e` from start-of-step coordinates; `RHSDriver`/`LHSDriver` hold it frozen across all Newton iterations of the step.
- New `FormStiffness` builds the per-element 12×12 tangent by forward FD on the F̄ residual at frozen J̄. Both residual and tangent read the same `fJbarE` → local tangent IS the consistent `∂R(u; J̄_step)/∂u`.
- Result on `tet4_hyperelastic_anp.xml` (κ=100, μ=40): **15× Newton-iteration reduction** (16 → 1 iter/step, linear → quadratic).

## Verification
- Confirmed `F̄ = (J̄/J)^(1/3) F` formulation against **Bonet & Burton 1998** (PDF in `ref/bonet1998.pdf`): gives `F̂_bar = F̂` (iso unchanged) and `det(F̄) = J̄` — equivalent to the iso/vol split in eqs (24)–(30) of the paper.
- The 1998 paper is **explicit-dynamics only** — it never derives an implicit tangent. Confirms why a complete fix is non-trivial.
- Plain Tet4 (`tet4_hyperelastic.xml`) still converges in 3 quadratic iters/step.
- ANPHelperT (5/5) and Tet4Kernel (5/5) unit tests pass.

## Known limitation
The per-element 12×12 FD tangent cannot express the cross-element `∂J̄/∂u` coupling (J̄ is nodal-averaged, so a node perturbation changes J̄ in every neighbouring element). At severe near-incompressibility (κ ≫ μ, e.g. `compress_bonet_tet.xml` with κ=1000, μ=1) the missing block kills the local volumetric stiffness and Newton diverges.

A fully consistent tangent would follow **Bonet/Marriott/Hassan 2001** or **Caylak/Mahnken 2012** — kept open as a future analytical-tangent extension of #29. Documented in `BonetTetT.h` and `benchmark_XML/level.5/README.md`.

## Test plan
- [x] `tet4_hyperelastic_anp.xml` — 5/5 steps, 1 iter each, quadratic
- [x] `tet4_hyperelastic.xml` — 5/5 steps, 3 iters each, quadratic
- [x] `ctest -R Tet4Kernel` — 5/5 pass
- [x] `ctest -R ANP` — 5/5 pass
- [ ] Run `compress_bonet_tet.xml` — expected to diverge under severe κ ≫ μ (documented limitation)