### PR TITLE
docs(benchmark_XML): per-level READMEs + consistent style

### DIFF
--- a/benchmark_XML/ReadMe
+++ b/benchmark_XML/ReadMe
@@ -1,32 +1,18 @@
 BENCHMARK TESTS
 -----------------------------------------------------------------------
 The benchmark suite verifies Tahoe's numerical correctness against
-reference solutions. Tests are organized into levels:
+reference solutions.  Tests are organised into levels; each level has
+its own README.md with the theme, subdirectory list, and status.
 
-  level.0  — Core capabilities (springs, solid mechanics, diffusion,
-              particle methods, meshfree, time integrators). All code
-              changes should pass these before committing.
-              Status: 172/186 PASS, 14 FAIL (May 2026; issue #37).
-              Remaining failures: 9 bridging tests (BRIDGING_ELEMENT
-              runtime crash — kept disabled), 5 real code regressions
-              (CSE.2 5-node-Q4, adhesion.{2,3} stress drift,
-              inputoutput/square × 2 output suppression).
+  level.0/README.md  — core capabilities
+  level.1/README.md  — constitutive model verification
+  level.2/README.md  — extended capabilities
+  level.3/README.md  — MPI distributed-memory parallel
+  level.4/README.md  — solver performance
+  level.5/README.md  — modernised-solver benchmarks
 
-  level.1  — Constitutive model verification under simple loading
-              (bulk materials, cohesive surface relations, atomistic
-              potentials).
-              Status: 100/103 PASS, 3 FAIL (May 2026).
-              Remaining failures: mat.2.a, mat.11.a (2D + 3D)
-              — unregistered material in factory.
-
-  level.2  — Extended capabilities. May involve larger models or
-              longer run times. No optional modules required.
-              Status: 47/47 PASS, 0 FAIL (May 2026, clean).
-
-  level.3  — MPI distributed-memory parallel tests. Requires
-              -DTAHOE_MPI=ON and system OpenMPI (libopenmpi-dev).
-              Run with mpirun -np 4. All 22 tests pass.
-
+This file documents the *running* and *comparison* mechanics that are
+common to all levels.
 
 BUILDING
 -----------------------------------------------------------------------

--- a/benchmark_XML/level.0/README.md
+++ b/benchmark_XML/level.0/README.md
@@ -1,0 +1,39 @@
+# Level 0 — Core capabilities
+
+Foundational regression tests covering every primary kernel: springs, solid
+mechanics, diffusion, particles, meshfree, time integrators, I/O.  All code
+changes should pass these before committing.
+
+Run from the level root:
+```bash
+cd benchmark_XML/level.0
+printf "run.batch\nquit\n" | ../../build/bin/tahoe    # run the suite
+printf "run.batch\nquit\n" | ../../build/bin/compare  # compare to references
+```
+
+## Subdirectories
+
+| Directory | Theme |
+|-----------|-------|
+| `2D.elastostatic/`, `3D.elastostatic/` | Static linear and large-strain solid mechanics; patch and CSE tests |
+| `2D.elastodynamic/`, `3D.elastodynamic/` | Dynamic solid mechanics, central-difference and Newmark integrators |
+| `2D.spring/`, `3D.spring/` | Truss and spring elements (smallest models in the suite) |
+| `2D.particle/`, `3D.particle/` | Particle methods (Lennard-Jones, harmonic, EAM smoke tests) |
+| `adhesion/` | Surface-to-surface adhesion (needs `ADHESION_ELEMENT` — enabled by default since #37) |
+| `axisymmetric/` | Axisymmetric solid mechanics |
+| `bridging/` | Atomistic-continuum coupling (needs `BRIDGING_ELEMENT` — currently off; runtime crash tracked in #37) |
+| `diffusion/` | Heat / mass transport, linear and hyperbolic |
+| `enhanced.strain/` | Enhanced-strain element formulations |
+| `inputoutput/` | I/O round-trip tests |
+| `integrator/` | Time-integrator verification (verlet, Newmark, HHT-α, …) |
+| `matrix_check/` | Linear-solver sanity checks against analytical inverses |
+| `meshfree/` | EFG / reproducing-kernel meshfree methods |
+| `phase_field/` | Phase-field fracture smoke tests |
+| `geometry/` | Shared `.geom` mesh files referenced by tests in sibling directories |
+
+## Status (May 2026, default build)
+
+172 / 186 PASS, 14 FAIL — all 14 remaining failures are real Tahoe code
+regressions tracked under issue #37 (9 bridging runtime crashes, plus
+`CSE.2.xml`, `adhesion.{2,3}.xml`, `inputoutput/square.xml`).  See
+[`../ReadMe`](../ReadMe) for the full status table.

--- a/benchmark_XML/level.1/README.md
+++ b/benchmark_XML/level.1/README.md
@@ -1,0 +1,28 @@
+# Level 1 — Constitutive model verification
+
+Material-model tests under simple loading paths.  Each subdirectory holds
+one or more *material.NN* (or *cohesive.NN*) cases that drive a single
+element / patch with prescribed strain so the constitutive response can be
+read off against an analytical reference.
+
+Run as the other levels:
+```bash
+cd benchmark_XML/level.1
+printf "run.batch\nquit\n" | ../../build/bin/tahoe
+printf "run.batch\nquit\n" | ../../build/bin/compare
+```
+
+## Subdirectories
+
+| Directory | Theme |
+|-----------|-------|
+| `material.solid/{1D,2D,3D}/material.NN/` | Bulk solid materials — linear elastic (`material.01`), elastoplastic (`material.02`), Drucker-Prager (`material.11`), hyperelastic Ogden / Mooney variants, etc.  Each subdir loads its material under a unit cell and checks stress vs analytical. |
+| `material.surface/{2D,3D}/cohesive.NN/` | Cohesive-zone surface laws — `cohesive.0X` covers Xu-Needleman, linear, exponential, ductile traction-separation models. |
+| `material.surface/{2D,3D}/SIMOD/` | SIMOD-format cohesive parameter conversion. |
+| `stress.smoothing/` | Nodal stress recovery / averaging on a Q4 patch. |
+
+## Status (May 2026)
+
+100 / 103 PASS, 3 FAIL.  Remaining failures: `material.solid/{2D,3D}/material.11/mat.11.a.xml`
+and `material.solid/2D/material.02/mat.2.a.xml` — unregistered materials in
+the factory, tracked under #37.

--- a/benchmark_XML/level.2/README.md
+++ b/benchmark_XML/level.2/README.md
@@ -1,0 +1,29 @@
+# Level 2 — Extended capabilities
+
+Larger / longer-running problems than levels 0–1, exercising whole feature
+combinations rather than single kernels.  No optional modules required.
+
+Run as the other levels:
+```bash
+cd benchmark_XML/level.2
+printf "run.batch\nquit\n" | ../../build/bin/tahoe
+printf "run.batch\nquit\n" | ../../build/bin/compare
+```
+
+## Subdirectories
+
+| Directory | Theme |
+|-----------|-------|
+| `K.field/` | Crack-tip K-field driven elastic / plastic patch (linear, large-strain, contour-integral variants). |
+| `angled_bc/` | Skew kinematic boundary conditions (BCs not aligned with global axes). |
+| `contact_simple/` | Frictionless penalty contact between simple Q4 / Hex8 bodies — the canonical contact regression. |
+| `conveyor/` | Periodic-domain conveyor / moving-mesh tests; exercises restart files and the `*.tracking` output. |
+| `force.controller/` | Prescribed-force controllers (PD, integrator-based) driving displacement BCs to a target traction. |
+| `thermostats/` | Particle-thermostat schemes (Nose-Hoover, Langevin) on Lennard-Jones systems. |
+| `tied/` | Tied-node constraints between dissimilar meshes. |
+| `torsion/` | Torsional loading on solid sections, large rotation. |
+| `geometry/` | Shared `.geom` files used by tests in sibling directories. |
+
+## Status (May 2026)
+
+47 / 47 PASS, 0 FAIL.  Level.2 is currently clean.

--- a/benchmark_XML/level.3/README.md
+++ b/benchmark_XML/level.3/README.md
@@ -1,0 +1,29 @@
+# Level 3 — MPI distributed-memory parallel
+
+Same kernels as levels 0–2, exercised under MPI domain decomposition with
+4 ranks.  Requires `-DTAHOE_MPI=ON` and system OpenMPI (`libopenmpi-dev`);
+do *not* use a conda MPI wrapper — see the top-level [`ReadMe`](../ReadMe).
+
+Run:
+```bash
+cd benchmark_XML/level.3/parallel
+/usr/bin/mpirun -np 4 ../../../build/bin/tahoe -f run.batch
+# compare (serial) against per-rank reference output:
+for x in *.xml; do ../../../build/bin/compare -f "$x"; done
+```
+The repo-root `run_benchmarks.sh level.3` automates both steps.
+
+## Subdirectories
+
+| File / dir | Theme |
+|------------|-------|
+| `parallel/elastostatic*.xml` | Static large-strain solid, three solver variants: profile (default), Newton + line search (`N-LS`), preconditioned CG (`PCG`), PCG with K-factor recompute (`PCG.K`). |
+| `parallel/explicit.dyn{.restart}?.xml` | Explicit central-difference dynamics, with and without restart-file write/read. |
+| `parallel/2D.particle/`, `3D.particle/` | Particle MD across ranks (cell-list communication, ghost atoms). |
+| `parallel/2D.particle.spatial/`, `3D.particle.spatial/` | Particle MD with spatially-decomposed neighbour search. |
+| `parallel/split_io/` | Multi-file output verification across ranks. |
+| `parallel/geometry/` | Shared `.geom` files (decomposition output `*.nN.pK.geom*` is git-ignored). |
+
+## Status (May 2026)
+
+22 / 22 PASS, 0 FAIL.  Level.3 is currently clean.

--- a/benchmark_XML/level.4/README.md
+++ b/benchmark_XML/level.4/README.md
@@ -1,10 +1,22 @@
-# Level 4 Benchmarks — Solver Performance
+# Level 4 — Solver performance
 
-Level 4 contains performance benchmarks for comparing sparse direct solvers. Unlike levels 0–3 (which test correctness), level 4 problems are designed to stress the linear solver with non-trivial DOF counts and multi-physics coupling.
+Performance benchmarks for comparing the bundled sparse direct solvers.
+Unlike levels 0–3 (correctness), level.4 problems are sized to stress the
+linear solver with non-trivial DOF counts and multi-physics coupling.
+
+## Subdirectories
+
+| Directory | Theme |
+|-----------|-------|
+| `liquid_inclusion/` | Dielectric elastomer with a circular hole — 4704 Q4, 18 832 DOFs (displacement + electric potential).  The headline solver-comparison case, detailed below. |
+| `single_element/` | Single-Hex8 sanity tests (monolithic vs staggered electro-mechanics; static and dynamic). |
+| `dielectric_elastomer_damage/` | Three-way and two-way coupled staggered runs for dielectric elastomer + phase-field damage. |
+| `surface_tension/` | 3D surface-tension Q1P0 patch test. |
+| `geometry/` | Shared `.geom` meshes referenced by the cases above (partitioned `*.nN.pK.geom*` files are git-ignored). |
 
 ---
 
-## Problem: Dielectric Elastomer with Liquid Inclusion (`liquid_inclusion/`)
+## Headline benchmark: dielectric elastomer with liquid inclusion (`liquid_inclusion/`)
 
 A 2D coupled electromechanical problem using the `dielectric_elastomer_Q1P0Elastocapillary` element (mixed Q1P0 pressure + electric scalar potential field). The mesh is a square domain with a circular hole (`ah025.geom`).
 

--- a/benchmark_XML/level.5/README.md
+++ b/benchmark_XML/level.5/README.md
@@ -1,9 +1,21 @@
-# Level 5 — Tahoe explicit-solver benchmarks
+# Level 5 — Modernised-solver benchmarks
 
-Benchmarks introduced alongside the modernised explicit-solver track
-(`ExplicitElementT`, MVSIZ-batched).  Each subdirectory has its own
-focus; tests reference these for performance baselines and physics
-verification.
+Benchmarks introduced alongside the modernised solver tracks — the explicit
+`ExplicitElementT` (MVSIZ-batched, 2026 modernisation) and the matching
+implicit additions on the classic `UpdatedLagrangianT` path (BonetTet ANP,
+implicit Coulomb friction).  Each subdirectory has its own focus; tests
+reference these for performance baselines and physics verification.
+
+## Subdirectories at a glance
+
+| Directory | Theme |
+|-----------|-------|
+| `explicit_benchmark/` | The original speed-up suite (legacy ↔ vectorized), plus growing feature-specific smoke tests (J2 plasticity, ANP-Tet4, contact, friction, hourglass control). |
+| `taylor_bar/` | Classic Taylor-bar impact, soft-metal demo (issue #18). |
+| `hertz/` | Hertz contact validation — Hex8-only and mixed Tet/Hex variants; explicit vs implicit cross-validated to within 0.5 %. |
+| `tet_classic/` | Implicit Tet4 path: plain `<updated_lagrangian>` and ANP `<bonet_tet>` variants (#27, #28, #29). |
+| `implicit_friction/` | Implicit Coulomb friction smoke test (#40) — currently diverges as expected pending the LHS friction tangent. |
+
 
 ## explicit_benchmark/
 
@@ -161,6 +173,26 @@ the explicit benchmarks above.
 > Bonet/Marriott/Hassan 2001 or Caylak/Mahnken 2012, kept open as a
 > future analytical-tangent extension of #29.
 
+## implicit_friction/
+
+Quasi-static counterpart to the explicit Coulomb friction benchmark
+(`explicit_benchmark/vectorized_cubes_friction.xml`, #26).  Same two-cube
+geometry driven by `<updated_lagrangian>` + Newton-Raphson with the
+slip-history Coulomb branch in `PenaltyContact3DT` (#40, PR #41).
+
+| File | Notes |
+|------|-------|
+| `sliding_cubes.xml` | Top face compressed (u_z = −0.005) and dragged tangentially (u_x = 0 → 0.01 over 100 steps); μ = 0.02. |
+| `two_cubes.geom` | Copy of `../explicit_benchmark/geometry/two_cubes_refined.geom`. |
+
+**Status: diverges as expected.** The implicit branch ships the residual
+and slip-history infrastructure, but `PenaltyContact3DT::LHSDriver` does
+not yet include the friction tangent `∂f_t/∂Δu_t`.  Newton has no way to
+predict the corrections needed and exits after iter 0.  The XML is kept
+here as the natural integration test for whoever adds the analytical
+friction tangent — it should flip from diverging to ~1–2 iter/step the
+moment the tangent lands.  See [`implicit_friction/README.md`](implicit_friction/README.md).
+
 ## Coverage matrix
 
 | Issue | Headline benchmark / test |
@@ -171,6 +203,8 @@ the explicit benchmarks above.
 | #26 Coulomb friction | `vectorized_cubes_friction.xml`, `tests/benchmarks/test_FrictionContact.cpp` |
 | #27 Tet4 kernel + Ji-fix | `vectorized_tet_*.xml`, `tests/kernels/test_Tet4Kernel.cpp` |
 | #28 ANP-Tet4 (ELFORM=13) | `vectorized_tet_anp_small.xml`, `tests/kernels/test_ANPHelperT.cpp`, `tet_classic/*` |
+| #29 BonetTet lagged-J̄ + FD tangent | `tet_classic/tet4_hyperelastic_anp.xml` (quadratic on moderate κ) |
 | #31/#32/#33 contact-stack perf | `tests/benchmarks/test_ContactPerf.cpp`, `vectorized_cubes_*.xml` (viscous damping, OMP threshold, parallel contact) |
+| #40 implicit Coulomb friction | `implicit_friction/sliding_cubes.xml` (residual only — diverges pending LHS tangent) |
 | Hertz contact validation | `hertz/hertz_explicit.xml`, `hertz/hertz_implicit.xml`, `hertz/compare_to_analytical.py` |
 | Mixed Tet/Hex contact | `hertz/hertz_tet_hex_*.xml`, `hertz/compare_tet_hex_to_analytical.py` |


### PR DESCRIPTION
## Summary
Aligns documentation style across the benchmark tree and fills the gaps:
- New: \`level.0/README.md\`, \`level.1/README.md\`, \`level.2/README.md\`, \`level.3/README.md\`.
- Polished: \`level.4/README.md\` (header reformatted, subdirectory index added) and \`level.5/README.md\` (subdirectory index, \`implicit_friction/\` section, #29 + #40 rows in the coverage matrix).
- Slimmed: top-level \`benchmark_XML/ReadMe\` now only documents the *running* and *comparison* mechanics common to all levels, plus a pointer list to each level's README.md.

## Style template
Every level README now follows the same shape:
1. \`# Level N — <theme>\` (em-dash, lowercase descriptor)
2. One-paragraph purpose statement
3. One-block run snippet (\`tahoe\` + \`compare\`)
4. Subdirectory table (one row per subdir, \"Theme\" column)
5. Status note (current PASS/FAIL count, link to #37 for known regressions)

## What did not change
- No XML / test data touched.
- No new test discovery; just documentation.
- Level.4's solver-comparison numbers and tables are preserved as-is.

## Test plan
- [x] All seven READMEs render correctly as markdown (tables, links, code fences).
- [x] No code changes → ctest unchanged.