### PR TITLE
cleanup(headers): add samanseifi $Id$ on modernisation-track files

### DIFF
--- a/tahoe/src/elements/contact/PenaltyContact3DT.cpp
+++ b/tahoe/src/elements/contact/PenaltyContact3DT.cpp
@@ -1,4 +1,5 @@
 /* $Id: PenaltyContact3DT.cpp,v 1.17 2011/12/01 21:11:36 bcyansfn Exp $ */
+/* $Id: PenaltyContact3DT.cpp,v 2.0 2026/05/08 samanseifi Exp $ */
 /* created: paklein (02/09/2000) */
 #include "PenaltyContact3DT.h"
 

--- a/tahoe/src/elements/contact/PenaltyContact3DT.h
+++ b/tahoe/src/elements/contact/PenaltyContact3DT.h
@@ -1,4 +1,5 @@
 /* $Id: PenaltyContact3DT.h,v 1.7 2004/07/15 08:26:08 paklein Exp $ */
+/* $Id: PenaltyContact3DT.h,v 2.0 2026/05/08 samanseifi Exp $ */
 /* created: paklein (02/09/2000) */
 #ifndef _PENALTY_CONTACT3D_T_H_
 #define _PENALTY_CONTACT3D_T_H_

--- a/tahoe/src/elements/continuum/solid/BonetTetT.cpp
+++ b/tahoe/src/elements/continuum/solid/BonetTetT.cpp
@@ -1,3 +1,4 @@
+/* $Id: BonetTetT.cpp,v 2.0 2026/05/08 samanseifi Exp $ */
 /* BonetTetT.cpp */
 #include "BonetTetT.h"
 

--- a/tahoe/src/elements/continuum/solid/BonetTetT.h
+++ b/tahoe/src/elements/continuum/solid/BonetTetT.h
@@ -1,3 +1,4 @@
+/* $Id: BonetTetT.h,v 2.0 2026/05/08 samanseifi Exp $ */
 /* BonetTetT.h — average-nodal-pressure Tet4 (Bonet & Burton 1998).
  *
  * Classic-Tahoe (UpdatedLagrangianT) element with the Bonet-Burton F-bar

--- a/tahoe/src/elements/explicit/ANPHelperT.cpp
+++ b/tahoe/src/elements/explicit/ANPHelperT.cpp
@@ -1,3 +1,4 @@
+/* $Id: ANPHelperT.cpp,v 2.0 2026/05/08 samanseifi Exp $ */
 /* ANPHelperT.cpp — Bonet-Burton 1998 average nodal pressure helper.
  *
  * The two-pass loop below uses #pragma omp atomic on the nodal scatter so

--- a/tahoe/src/elements/explicit/ANPHelperT.h
+++ b/tahoe/src/elements/explicit/ANPHelperT.h
@@ -1,3 +1,4 @@
+/* $Id: ANPHelperT.h,v 2.0 2026/05/08 samanseifi Exp $ */
 /* ANPHelperT.h — average nodal pressure (Bonet-Burton 1998) F-bar helper.
  *
  * Equivalent to LS-DYNA ELFORM=13 for tet4: averages the dilatation

--- a/tahoe/src/elements/explicit/ExplicitElementT.cpp
+++ b/tahoe/src/elements/explicit/ExplicitElementT.cpp
@@ -1,3 +1,4 @@
+/* $Id: ExplicitElementT.cpp,v 2.0 2026/05/08 samanseifi Exp $ */
 /* ExplicitElementT.cpp — MVSIZ-batched explicit solid element. */
 #include "ExplicitElementT.h"
 

--- a/tahoe/src/elements/explicit/ExplicitElementT.h
+++ b/tahoe/src/elements/explicit/ExplicitElementT.h
@@ -1,3 +1,4 @@
+/* $Id: ExplicitElementT.h,v 2.0 2026/05/08 samanseifi Exp $ */
 /* ExplicitElementT.h — MVSIZ-batched explicit solid element.
  *
  * Derives from SolidElementT to reuse mass matrix assembly, equation

--- a/tahoe/src/elements/explicit/kernels/ExplicitKernelT.h
+++ b/tahoe/src/elements/explicit/kernels/ExplicitKernelT.h
@@ -1,3 +1,4 @@
+/* $Id: ExplicitKernelT.h,v 2.0 2026/05/08 samanseifi Exp $ */
 /* ExplicitKernelT.h — abstract element topology kernel for explicit dynamics.
  *
  * A kernel encapsulates the element geometry: shape functions, parent domain

--- a/tahoe/src/elements/explicit/kernels/Hex8KernelT.cpp
+++ b/tahoe/src/elements/explicit/kernels/Hex8KernelT.cpp
@@ -1,3 +1,4 @@
+/* $Id: Hex8KernelT.cpp,v 2.0 2026/05/08 samanseifi Exp $ */
 /* Hex8KernelT.cpp — 8-node hexahedral, 2x2x2 Gauss integration. */
 #include "Hex8KernelT.h"
 

--- a/tahoe/src/elements/explicit/kernels/Hex8KernelT.h
+++ b/tahoe/src/elements/explicit/kernels/Hex8KernelT.h
@@ -1,3 +1,4 @@
+/* $Id: Hex8KernelT.h,v 2.0 2026/05/08 samanseifi Exp $ */
 /* Hex8KernelT.h — 8-node hexahedral kernel for 3D explicit dynamics. */
 
 #ifndef _HEX8_KERNEL_T_H_

--- a/tahoe/src/elements/explicit/kernels/Q4KernelT.cpp
+++ b/tahoe/src/elements/explicit/kernels/Q4KernelT.cpp
@@ -1,3 +1,4 @@
+/* $Id: Q4KernelT.cpp,v 2.0 2026/05/08 samanseifi Exp $ */
 /* Q4KernelT.cpp — 4-node quadrilateral, 2x2 Gauss integration. */
 #include "Q4KernelT.h"
 

--- a/tahoe/src/elements/explicit/kernels/Q4KernelT.h
+++ b/tahoe/src/elements/explicit/kernels/Q4KernelT.h
@@ -1,3 +1,4 @@
+/* $Id: Q4KernelT.h,v 2.0 2026/05/08 samanseifi Exp $ */
 /* Q4KernelT.h — 4-node quadrilateral kernel for 2D explicit dynamics. */
 
 #ifndef _Q4_KERNEL_T_H_

--- a/tahoe/src/elements/explicit/kernels/Tet4KernelT.cpp
+++ b/tahoe/src/elements/explicit/kernels/Tet4KernelT.cpp
@@ -1,3 +1,4 @@
+/* $Id: Tet4KernelT.cpp,v 2.0 2026/05/08 samanseifi Exp $ */
 /* Tet4KernelT.cpp — 4-node constant-strain tet, 1-point integration.
  *
  * Parametric coords (r,s,t) on the reference unit tet:

--- a/tahoe/src/elements/explicit/kernels/Tet4KernelT.h
+++ b/tahoe/src/elements/explicit/kernels/Tet4KernelT.h
@@ -1,3 +1,4 @@
+/* $Id: Tet4KernelT.h,v 2.0 2026/05/08 samanseifi Exp $ */
 /* Tet4KernelT.h — 4-node constant-strain tetrahedron kernel for 3D explicit
  * dynamics.  Single integration point at the centroid (parametric coords
  * r=s=t=1/4), weight = 1/6 (volume of the unit reference tet).

--- a/tahoe/src/elements/explicit/materials/ExplJ2PlasticityT.cpp
+++ b/tahoe/src/elements/explicit/materials/ExplJ2PlasticityT.cpp
@@ -1,3 +1,4 @@
+/* $Id: ExplJ2PlasticityT.cpp,v 2.0 2026/05/08 samanseifi Exp $ */
 /* ExplJ2PlasticityT.cpp — batch finite-strain J2 plasticity.
  *
  * Hughes-Winget incremental-objective update:

--- a/tahoe/src/elements/explicit/materials/ExplJ2PlasticityT.h
+++ b/tahoe/src/elements/explicit/materials/ExplJ2PlasticityT.h
@@ -1,3 +1,4 @@
+/* $Id: ExplJ2PlasticityT.h,v 2.0 2026/05/08 samanseifi Exp $ */
 /* ExplJ2PlasticityT.h — batch finite-strain J2 plasticity for explicit dynamics.
  *
  * Hughes-Winget incremental-objective algorithm with isotropic linear hardening.

--- a/tahoe/src/elements/explicit/materials/ExplNeoHookeanT.cpp
+++ b/tahoe/src/elements/explicit/materials/ExplNeoHookeanT.cpp
@@ -1,3 +1,4 @@
+/* $Id: ExplNeoHookeanT.cpp,v 2.0 2026/05/08 samanseifi Exp $ */
 /* ExplNeoHookeanT.cpp — batch Neo-Hookean Cauchy stress.
  *
  * Compressible Neo-Hookean:

--- a/tahoe/src/elements/explicit/materials/ExplNeoHookeanT.h
+++ b/tahoe/src/elements/explicit/materials/ExplNeoHookeanT.h
@@ -1,3 +1,4 @@
+/* $Id: ExplNeoHookeanT.h,v 2.0 2026/05/08 samanseifi Exp $ */
 /* ExplNeoHookeanT.h — batch Neo-Hookean material for explicit dynamics.
  *
  * Compressible Neo-Hookean in current configuration (updated Lagrangian).

--- a/tahoe/src/elements/explicit/materials/ExplicitMaterialT.h
+++ b/tahoe/src/elements/explicit/materials/ExplicitMaterialT.h
@@ -1,3 +1,4 @@
+/* $Id: ExplicitMaterialT.h,v 2.0 2026/05/08 samanseifi Exp $ */
 /* ExplicitMaterialT.h — abstract batch material interface for explicit dynamics.
  *
  * A batch material computes Cauchy stress from the deformation gradient F

--- a/tests/kernels/test_ANPHelperT.cpp
+++ b/tests/kernels/test_ANPHelperT.cpp
@@ -1,3 +1,4 @@
+/* $Id: test_ANPHelperT.cpp,v 2.0 2026/05/08 samanseifi Exp $ */
 /* test_ANPHelperT.cpp — unit tests for the Bonet-Burton ANP helper.
  *
  * Verifies the J-gather / nodal-average / J-bar-scatter pipeline on

--- a/tests/kernels/test_Tet4Kernel.cpp
+++ b/tests/kernels/test_Tet4Kernel.cpp
@@ -1,3 +1,4 @@
+/* $Id: test_Tet4Kernel.cpp,v 2.0 2026/05/08 samanseifi Exp $ */
 /* test_Tet4Kernel.cpp — unit tests for Tet4KernelT.
  *
  * Verifies geometry-only properties of the 4-node constant-strain tet:


### PR DESCRIPTION
## Summary
Adds a single CVS-\$Id\$-style attribution line on the modernisation-track files (the 2026 explicit element, kernels, materials, ANP helper, BonetTet, plus the matching gtests).  Format matches the legacy header style already used throughout the tree, so the existing convention is preserved:

\`\`\`c
/* \$Id: <file>,v 2.0 2026/05/08 samanseifi Exp \$ */
\`\`\`

For files that already had a paklein/\$Id\$ header from the original Tahoe release (e.g. \`PenaltyContact3DT\` — touched for #26 / #40), the original line is left intact and the new samanseifi \$Id\$ is added just below.  No existing legacy attribution is modified or removed.

## Scope
22 files, +1 line each:
- New 2026 explicit-track files: \`ExplicitElementT.{h,cpp}\`, four kernels, three materials, \`ANPHelperT.{h,cpp}\`, \`BonetTetT.{h,cpp}\`, the two new gtests.
- Updated legacy files: \`PenaltyContact3DT.{h,cpp}\` (added a second \$Id\$ below paklein's).

## Test plan
- [x] No code changes; just attribution comment lines.
- [x] Full build: \`cmake --build build\` clean.
- [x] ctest unchanged (Tet4Kernel 5/5, ANP 5/5, ExplJ2Plasticity, NeoHookean, etc.).