### PR TITLE
#37 enable PLASTICITY_DP_MATERIAL + drop mat.2.a ExodusII — level.1 clean

### DIFF
--- a/benchmark_XML/level.1/material.solid/2D/material.02/mat.2.a.echo.xml
+++ b/benchmark_XML/level.1/material.solid/2D/material.02/mat.2.a.echo.xml
@@ -4,7 +4,6 @@
       xmlns:x0='http://www.w3.org/2001/XMLSchema'
         author='paklein'
  geometry_file='../geometry/square.1.geom'
- output_format='ExodusII'
          title='2D uniaxial tension'>
 	<time
 	  num_steps='2'

--- a/benchmark_XML/level.1/material.solid/2D/material.02/mat.2.a.out
+++ b/benchmark_XML/level.1/material.solid/2D/material.02/mat.2.a.out
@@ -8,7 +8,7 @@ geometry_format = automatic (default)
 geometry_format = TahoeII
 geometry_format = ExodusII
 geometry_file. . . . . . . . . . . . . . . . . . . = ../geometry/square.1.geom
-output_format. . . . . . . . . . . . . . . . . . . = ExodusII
+output_format. . . . . . . . . . . . . . . . . . . = automatic
 output_format = automatic (default)
 output_format = Tahoe
 output_format = TecPlot
@@ -299,10 +299,10 @@ end: tahoe
  Time = 1.000000e+00
  Step 2 of 2
 
-   Start time: Fri Feb 27 20:21:16 2026
- Construction: 3.618000e-03 sec.
-     Solution: 1.924000e-02 sec.
-    Stop time: Fri Feb 27 20:21:16 2026
+   Start time: Sun May 17 17:25:33 2026
+ Construction: 5.836000e-03 sec.
+     Solution: 2.180000e-03 sec.
+    Stop time: Sun May 17 17:25:33 2026
 
  End Execution
 

--- a/benchmark_XML/level.1/material.solid/2D/material.02/mat.2.a.valid.xml
+++ b/benchmark_XML/level.1/material.solid/2D/material.02/mat.2.a.valid.xml
@@ -5,7 +5,7 @@
              author='paklein'
     geometry_format='automatic'
       geometry_file='../geometry/square.1.geom'
-      output_format='ExodusII'
+      output_format='automatic'
  restart_output_inc='0'
          echo_input='false'
             logging='moderate'

--- a/benchmark_XML/level.1/material.solid/2D/material.02/mat.2.a.xml
+++ b/benchmark_XML/level.1/material.solid/2D/material.02/mat.2.a.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tahoe xmlns:x0="http://www.w3.org/2001/XMLSchema" author="paklein" geometry_file="../geometry/square.1.geom" output_format="ExodusII" title="2D uniaxial tension">
+<tahoe xmlns:x0="http://www.w3.org/2001/XMLSchema" author="paklein" geometry_file="../geometry/square.1.geom" title="2D uniaxial tension">
     <time num_steps="2" output_inc="1" time_step="0.5">
         <schedule_function>
             <piecewise_linear>

--- a/tahoe/config/SolidMaterialsConfig.h
+++ b/tahoe/config/SolidMaterialsConfig.h
@@ -66,7 +66,7 @@
  * Drucker-Prager plasticity models.
  * This option must be set in conjunction with the DIRECTORY_PLASTICITY_DP_MATERIAL macro
  * in SolidMaterialsConfig.make. */
-/* #define PLASTICITY_DP_MATERIAL 1 */
+#define PLASTICITY_DP_MATERIAL 1
 
 /** \def GEOMODEL_MATERIAL
  * Sandia Geomodel plasticity model.


### PR DESCRIPTION
## Summary
Two more level.1 sub-failures from #37 cleared.  Same small-config-flip pattern as PR #38 (\`ADHESION_ELEMENT\` enable + diffusion XML format drop):

1. **\`tahoe/config/SolidMaterialsConfig.h\`** — enable \`PLASTICITY_DP_MATERIAL\` (was commented out).  Registers \`small_strain_StVenant_DP_2D\` and its 3D variant in the material factory.  Recovers \`material.solid/{2D,3D}/material.11/mat.11.a.xml\` (Drucker-Prager + linear hardening, σ_y = 0.04, α̅ = 0.15).

2. **\`benchmark_XML/level.1/material.solid/2D/material.02/mat.2.a.xml\`** — drop \`output_format=\"ExodusII\"\` so the default \"automatic\" resolves to Tahoe text format, matching the \`.run\` reference + comparator.  Same fix that #37 PR #38 applied to \`diffusion/heat.0.xml\`.  Recovers \`mat.2.a.xml\`.

## Verification

| Level | Before | After |
|-------|--------|-------|
| level.0 | 167 / 186 PASS, 19 FAIL | 167 / 186 PASS, 19 FAIL (unchanged) |
| level.1 | 100 / 103 PASS, 3 FAIL | **103 / 103 PASS, 0 FAIL** |
| level.2 | 47 / 47 PASS, 0 FAIL | 47 / 47 PASS, 0 FAIL (unchanged) |
| level.3 (MPI) | 22 / 22 PASS | 22 / 22 PASS |
| **Total** | 336 / 19 | **339 / 19** |

\`ctest -j$(nproc)\` → 64/64 PASS.

## Note on the level.0 baseline correction
The PR #38 message claimed \`level.0 = 172/14\` and credited the five \`2D.elastostatic/hex2D_CB_*\` tests as fixed by enabling \`ADHESION_ELEMENT\`.  Re-running each of those today on default build shows they still require \`BRIDGING_ELEMENT\` (\`tahoe_bridging\` element registration) and fail with \"requires BRIDGING_ELEMENT\".  They never actually passed on default build — the earlier count was inflated by ~5.

This PR uses the corrected honest baseline (\`level.0 = 167/19\`) in its before/after numbers.  Real cumulative improvement from #37 work so far: **322/35 (Feb) → 339/19 (today), 17 fewer failures**.

## Test plan
- [x] level.1 → 103/103 PASS
- [x] level.0 + level.2 unchanged
- [x] \`ctest -j\$(nproc)\` 64/64 PASS