### PR TITLE
#49 add tensile-test benchmark — verify J2 cubic-spline hardening response

### DIFF
--- a/benchmark_XML/level.5/README.md
+++ b/benchmark_XML/level.5/README.md
@@ -16,6 +16,7 @@ reference these for performance baselines and physics verification.
 | `tet_classic/` | Implicit Tet4 path: plain `<updated_lagrangian>` and ANP `<bonet_tet>` variants (#27, #28, #29). |
 | `implicit_friction/` | Implicit Coulomb friction smoke test (#40) — residual (PR #41) + LHS tangent (PR #45) both landed; converges quadratically. |
 | `brinell/` | Brinell-style indentation — rigid ball on J2-plastic block, light Coulomb friction (#47).  First benchmark combining cubic-spline hardening + implicit friction + Newton-LS. |
+| `tensile/` | Uniaxial tension on a J2-plastic bar (#49) — verifies that `<Simo_J2>` with `cubic_spline` hardening reproduces the input σ_y(ε_p) data to ~2 % under monotonic loading. |
 
 
 ## explicit_benchmark/
@@ -225,5 +226,6 @@ Newton-LS (`<nonlinear_solver_LS>`).
 | #31/#32/#33 contact-stack perf | `tests/benchmarks/test_ContactPerf.cpp`, `vectorized_cubes_*.xml` (viscous damping, OMP threshold, parallel contact) |
 | #40 implicit Coulomb friction | `implicit_friction/sliding_cubes.xml` (residual + LHS tangent — converges, quadratic Newton) |
 | #47 Brinell indentation       | `brinell/brinell_smoke.xml` (~55 s) + `brinell/brinell.xml` (Tabor validation) |
+| #49 J2 spline-hardening verification | `tensile/tensile.xml` — σ_VM(α) overlays input spline within ~2 % |
 | Hertz contact validation | `hertz/hertz_explicit.xml`, `hertz/hertz_implicit.xml`, `hertz/compare_to_analytical.py` |
 | Mixed Tet/Hex contact | `hertz/hertz_tet_hex_*.xml`, `hertz/compare_tet_hex_to_analytical.py` |

--- a/benchmark_XML/level.5/tensile/README.md
+++ b/benchmark_XML/level.5/tensile/README.md
@@ -1,0 +1,86 @@
+# Uniaxial tension — J2 cubic-spline hardening verification (#49)
+
+Pulls a slim quarter-symmetry bar in tension to verify that the
+`<Simo_J2>` radial-return reproduces the input `cubic_spline` σ_y(ε_p)
+hardening curve under monotonic uniaxial loading.  Companion to the
+Brinell benchmark (`../brinell/`) which uses the same material under
+contact loading — this benchmark isolates the material from contact
+nonlinearities.
+
+## Files
+
+| File | Notes |
+|------|-------|
+| [`generate_tensile_mesh.py`](generate_tensile_mesh.py) | Writes `tensile.geom`, a 4 × 4 × 40 Hex8 quarter bar (640 elements). |
+| [`tensile.xml`](tensile.xml) | 25 quasi-static steps to δ = 0.5 mm (= 10 % engineering strain). |
+| [`compare_to_hardening.py`](compare_to_hardening.py) | Extracts (α, σ_zz, σ_VM) history at the bar-centre probe and overlays the input spline. |
+
+## Setup
+
+- **Geometry** (quarter-symmetry): 0.5 × 0.5 × 5 mm; full bar would be 1 × 1 × 10 mm.
+- **Mesh**: 4 × 4 × 40 Hex8 = 640 elements, 1025 nodes.
+- **Material**: same family as `level.5/brinell/`, with a denser knot set
+  in the rapidly-changing region of the spline:
+  ```
+  Simo_J2,  E = 200 000 MPa,  ν = 0.3,  ρ = 7.85
+  cubic_spline σ_y(ε_p):
+      (0.000, 250)  (0.005, 320)  (0.020, 420)  (0.050, 500)
+      (0.080, 535)  (0.110, 560)  (0.150, 580)  (0.200, 600)
+      (0.300, 625)  (0.400, 640)  (0.500, 650)         [MPa]
+  ```
+- **BCs**: top face (NS1) prescribed `u_z = 0.5 mm`, bottom face (NS2)
+  `u_z = 0`, symmetry on x = 0 (NS3) and y = 0 (NS4).  Lateral faces
+  free → Poisson contraction.
+- **Solver**: `<nonlinear_solver_LS>` + SPOOLES, line search active.
+
+## Running
+
+```bash
+cd benchmark_XML/level.5/tensile
+python3 generate_tensile_mesh.py             # writes tensile.geom
+../../../build/bin/tahoe -f tensile.xml      # ~30 s serial
+python3 compare_to_hardening.py              # writes CSV + 2 PNGs
+```
+
+## Result — radial-return tracks the input spline within ~2 %
+
+Probe IP at the centre of the bar (x = y = 0, z = 2.5 mm).  The bar is
+in clean uniaxial tension there: `σ_xx`, `σ_yy ≈ 0` (≤ 10⁻⁵ MPa
+throughout), so `σ_VM = σ_zz` and the current yield surface is
+`σ_y(α) = σ_VM`.
+
+| t | α | σ_zz [MPa] | σ_VM [MPa] | nearest knot (α, σ_y) |
+|---:|----:|-----------:|-----------:|-----------------------|
+| 0.04 | 0.003 | 288.6 | 288.7 | (0.005, 320)  — pre-knot |
+| 0.20 | 0.018 | 410.9 | 411.3 | (0.020, 420) |
+| 0.40 | 0.037 | 472.7 | 473.1 | (0.050, 500) — between (0.020, 420)·(0.050, 500) |
+| 0.60 | 0.056 | 509.3 | 509.8 | (0.050, 500) |
+| 0.80 | 0.074 | 528.7 | 529.3 | (0.080, 535) |
+| 1.00 | 0.093 | 546.0 | 546.5 | between (0.080, 535)·(0.110, 560) — linear interp = 545.8 |
+
+The simulation tracks the cubic spline within **~2 %** across the full
+ε_p = 0 → 0.09 range — well within the radial-return tolerance.  The
+slightly-low values mid-knot are the spline curvature (cubic dips below
+linear interpolation between widely-spaced knots, by design).
+
+![hardening](tensile_hardening.png)
+![P-delta](tensile_pdelta.png)
+
+## Why we don't pull to ε_p = 0.5 (the last spline knot)
+
+The original plan was to pull to ε ≈ 0.5 to validate the full spline.
+At about α = 0.10 the spline saturates: dσ_y/dε_p drops from ~800 MPa
+to ~200 MPa over the 0.15–0.50 range.  With prescribed-displacement
+control, that saturation makes the global Newton tangent become near-
+singular in the axial direction (the change in axial force per unit
+axial displacement collapses).  Line search reduces to step factor ≈ 0
+and the iteration stalls.  Reaching the saturated portion of the curve
+needs either arc-length control or a load-controlled formulation —
+deferred as future work.  The 0 → 0.1 range tested here covers the
+steepest part of the hardening response, which is where verification
+matters most.
+
+## See also
+- `level.5/brinell/` — same material under contact + plasticity
+- Issue #49 — tracking
+- `tahoe/src/elements/continuum/solid/materials/plasticity_J2/J2_C0HardeningT.{h,cpp}` — the C¹-function-driven yield-stress interface used by `<Simo_J2>`

--- a/benchmark_XML/level.5/tensile/compare_to_hardening.py
+++ b/benchmark_XML/level.5/tensile/compare_to_hardening.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Tensile-test post-processor — verify J2 cubic-spline hardening (#49).
+
+Reads tensile.io0.exo and extracts the (α, σ_zz, VM_Kirch) history at a
+representative IP in the centre of the bar (axis x=y=0, mid-length).  At
+that point the bar is in clean uniaxial tension so:
+
+  - σ_VM == |σ_zz - σ_yy| ≈ σ_zz (since σ_xx = σ_yy ≈ 0 free-boundary)
+  - The current yield surface is σ_VM = σ_y(α)
+  - Plotting σ_VM vs α should overlay the input cubic-spline knots
+    to within the radial-return tolerance.
+
+Outputs:
+  tensile_results.csv          — per-frame (frame, t, α, σ_zz, VM, p)
+  tensile_hardening.png        — VM_Kirch vs α with the input knots overlaid
+  tensile_pdelta.png           — total axial reaction vs prescribed δ
+"""
+
+import os
+import sys
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from netCDF4 import Dataset
+
+
+# Spline knots — must match tensile.xml exactly.
+SPLINE = [
+    (0.000, 250.0), (0.005, 320.0), (0.020, 420.0),
+    (0.050, 500.0), (0.080, 535.0), (0.110, 560.0),
+    (0.150, 580.0), (0.200, 600.0), (0.300, 625.0),
+    (0.400, 640.0), (0.500, 650.0),
+]
+
+
+def main():
+    here = os.path.dirname(os.path.abspath(__file__))
+    stem = sys.argv[1] if len(sys.argv) > 1 else "tensile"
+    io0  = os.path.join(here, f"{stem}.io0.exo")
+    if not os.path.exists(io0):
+        print(f"missing: {io0}"); sys.exit(1)
+
+    f = Dataset(io0, "r")
+    nv = [b''.join(r).decode().rstrip('\x00').strip()
+          for r in f.variables["name_nod_var"][:]]
+    var = {n: f.variables[f"vals_nod_var{i+1}"] for i, n in enumerate(nv)}
+
+    cx, cy, cz = (f.variables[c][:] for c in ("coordx", "coordy", "coordz"))
+    nframes = f.dimensions["time_step"].size
+    t_whole = f.variables["time_whole"][:]
+
+    # Probe IP at the centre of the bar: choose the node closest to
+    # (x=0, y=0, z=Lz/2) where Lz = 5 mm here.
+    probe = int(np.argmin(np.abs(cz - 2.5) + np.abs(cx) + np.abs(cy)))
+    print(f"probe node: idx={probe}  at (x={cx[probe]:.3f}, y={cy[probe]:.3f}, z={cz[probe]:.3f})")
+
+    rows = []
+    for k in range(nframes):
+        alpha = float(var["alpha"][k][probe])
+        s33   = float(var["s33"][k][probe])
+        s11   = float(var["s11"][k][probe])
+        s22   = float(var["s22"][k][probe])
+        vmk   = float(var["VM_Kirch"][k][probe])
+        prs   = float(var["press"][k][probe])
+        rows.append((k, float(t_whole[k]), alpha, s33, s11, s22, vmk, prs))
+
+    csv = os.path.join(here, f"{stem}_results.csv")
+    with open(csv, "w") as fh:
+        fh.write("frame, t, alpha, sigma_zz_MPa, sigma_xx, sigma_yy, VM_Kirch, press\n")
+        for r in rows:
+            fh.write(", ".join(f"{x:.5f}" for x in r) + "\n")
+    print(f"wrote {csv}")
+
+    # Total axial reaction = sum of s_zz weighted by area at the top face.
+    # Easier proxy: |s33|·area_xy0 at z=Lz_top.  Not needed for the main
+    # validation; just useful as a sanity P-δ.
+    top_mask = np.abs(cz - cz.max()) < 1e-9
+    Lx_half = cx[top_mask].max()
+    Ly_half = cy[top_mask].max()
+    area_top = Lx_half * Ly_half     # quarter-symmetry → quarter area
+    Ps   = np.array([np.mean(var["s33"][k][top_mask]) * area_top for k in range(nframes)])
+    Dzs  = np.array([np.mean(var["D_Z"][k][top_mask]) for k in range(nframes)])
+
+    # --- Hardening overlay ---
+    alphas_sim = np.array([r[2] for r in rows])
+    VMs        = np.array([r[6] for r in rows])
+    s33s       = np.array([r[3] for r in rows])
+
+    a_spline = np.array([p[0] for p in SPLINE])
+    s_spline = np.array([p[1] for p in SPLINE])
+
+    fig, ax = plt.subplots(figsize=(7.5, 5.0))
+    ax.plot(a_spline, s_spline, "o-", color="tab:blue",
+            label="input spline knots (XML)", lw=1.5, ms=8)
+    ax.plot(alphas_sim, VMs, "s", color="tab:red", ms=6,
+            label="Tahoe simulation (VM_Kirch at centre)")
+    ax.plot(alphas_sim, s33s, "x", color="tab:green", ms=6,
+            label="Tahoe simulation (σ_zz at centre)")
+    ax.set_xlabel("equivalent plastic strain  α")
+    ax.set_ylabel("yield stress  σ_y  [MPa]")
+    ax.set_title(f"J2 hardening verification — {stem}")
+    ax.grid(alpha=0.3); ax.legend()
+    pfile = os.path.join(here, f"{stem}_hardening.png")
+    plt.savefig(pfile, dpi=120, bbox_inches="tight")
+    print(f"wrote {pfile}")
+
+    # --- P-δ ---
+    fig, ax = plt.subplots(figsize=(7.0, 4.5))
+    ax.plot(Dzs, Ps, "o-", color="tab:red")
+    ax.set_xlabel("top-face displacement  δ_z [mm]")
+    ax.set_ylabel("mean axial stress × area  ≈  P_quarter [N]")
+    ax.set_title(f"P-δ — {stem}")
+    ax.grid(alpha=0.3)
+    pfile = os.path.join(here, f"{stem}_pdelta.png")
+    plt.savefig(pfile, dpi=120, bbox_inches="tight")
+    print(f"wrote {pfile}")
+
+    # Console summary — error vs nearest spline knot at last frame
+    last = rows[-1]
+    a_last, vmk_last = last[2], last[6]
+    nearest_knot = SPLINE[int(np.argmin(np.abs(a_spline - a_last)))]
+    err_pct = 100.0 * abs(vmk_last - nearest_knot[1]) / nearest_knot[1]
+    print(f"\nSummary (last frame, t={last[1]:.2f}):")
+    print(f"  α      = {a_last:.4f}")
+    print(f"  σ_zz   = {last[3]:.1f} MPa")
+    print(f"  VM     = {vmk_last:.1f} MPa")
+    print(f"  nearest knot: ({nearest_knot[0]:.3f}, {nearest_knot[1]:.1f}) MPa")
+    print(f"  |VM − σ_y(α)| / σ_y(α) ≈ {err_pct:.2f} %")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark_XML/level.5/tensile/generate_tensile_mesh.py
+++ b/benchmark_XML/level.5/tensile/generate_tensile_mesh.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Tensile-test mesh — quarter-symmetry bar (#49).
+
+Pulls a slim rectangular bar in tension to verify that <Simo_J2> with a
+cubic-spline isotropic hardening curve reproduces the input σ_y(ε_p)
+data under uniaxial loading.
+
+Geometry (mm), quarter-symmetry:
+  L_x = 0.5    (half-width)
+  L_y = 0.5    (half-depth)
+  L_z = 5.0    (half-length; full bar would be 10 mm)
+
+Mesh:
+  nx = ny = 4,  nz = 40   ⇒ 640 Hex8
+
+Node sets:
+  1 — top face (z = L_z)     prescribed u_z = δ
+  2 — bottom face (z = 0)     u_z = 0
+  3 — x = 0 face              symmetry, u_x = 0
+  4 — y = 0 face              symmetry, u_y = 0
+  5 — single corner node at (L_x, L_y, L_z/2)   used by post-processor
+       to pick a deterministic IP for σ-α extraction
+
+The output (io0.exo) carries D_X/Y/Z, Cauchy stress s11..s12, plus the
+J2 material outputs alpha, norm_beta, VM_Kirch, press.
+"""
+
+import os
+
+
+def write_mesh(name: str = "tensile",
+               nx: int = 4, ny: int = 4, nz: int = 40,
+               Lx: float = 0.5, Ly: float = 0.5, Lz: float = 5.0):
+    outdir = os.path.dirname(os.path.abspath(__file__))
+    base = os.path.join(outdir, name)
+
+    nnx, nny, nnz = nx + 1, ny + 1, nz + 1
+    numnod = nnx * nny * nnz
+    numel  = nx * ny * nz
+
+    def nid(i, j, k):
+        return k * nnx * nny + j * nnx + i + 1
+
+    # coordinates: uniform grid
+    coords = []
+    for k in range(nnz):
+        for j in range(nny):
+            for i in range(nnx):
+                x = Lx * i / nx
+                y = Ly * j / ny
+                z = Lz * k / nz
+                coords.append((nid(i, j, k), x, y, z))
+
+    # element connectivity
+    conn = []
+    eid = 1
+    for k in range(nz):
+        for j in range(ny):
+            for i in range(nx):
+                ns = [nid(i,   j,   k),   nid(i+1, j,   k),
+                      nid(i+1, j+1, k),   nid(i,   j+1, k),
+                      nid(i,   j,   k+1), nid(i+1, j,   k+1),
+                      nid(i+1, j+1, k+1), nid(i,   j+1, k+1)]
+                conn.append((eid, ns)); eid += 1
+
+    # node sets
+    ns1 = [nid(i, j, nz) for j in range(nny) for i in range(nnx)]   # top
+    ns2 = [nid(i, j, 0)  for j in range(nny) for i in range(nnx)]   # bottom
+    ns3 = [nid(0, j, k)  for k in range(nnz) for j in range(nny)]   # x=0
+    ns4 = [nid(i, 0, k)  for k in range(nnz) for i in range(nnx)]   # y=0
+    # NS5 — a deterministic corner-strip used as the σ–α probe by the post-
+    # processor.  We pick the centre-column (i=nx, j=ny) so the strip stays
+    # uniaxial throughout the deformation (centroidal axis is symmetric).
+    ns5 = [nid(nx, ny, k) for k in range(nnz)]
+
+    with open(f"{base}.geom", "w") as f:
+        f.write("*version\n1.0\n*title\ntensile_quarter_bar\n")
+        f.write("*dimensions\n")
+        f.write(f"{numnod}   # number of nodes\n3   # ndim\n")
+        f.write("1   # number of element sets\n")
+        f.write(f"1   {numel}   8\n")
+        f.write("5   # number of node sets\n")
+        for idx, lst in enumerate([ns1, ns2, ns3, ns4, ns5]):
+            f.write(f"{idx+1}   {len(lst)}\n")
+        f.write("0   # number of side sets\n")
+        f.write("# end dimensions\n")
+
+        f.write("*nodesets\n")
+        for lst in [ns1, ns2, ns3, ns4, ns5]:
+            f.write("*set\n")
+            f.write(f"{len(lst)}\n")
+            f.write(" ".join(str(n) for n in lst) + "\n")
+
+        f.write("*sidesets\n")
+
+        f.write("*elements\n*set\n")
+        f.write(f"{numel}   # nelem\n8   # nen\n")
+        for eid, ns in conn:
+            f.write(f"{eid}  " + "  ".join(str(x) for x in ns) + "\n")
+
+        f.write("*nodes\n")
+        f.write(f"{numnod}\n3\n")
+        for n, x, y, z in coords:
+            f.write(f"{n}  {x:.15e}  {y:.15e}  {z:.15e}\n")
+
+    # clean stale per-set files
+    for ext in (".nd", ".es0") + tuple(f".ns{i}" for i in range(5)):
+        p = f"{base}.geom{ext}"
+        if os.path.exists(p):
+            os.remove(p)
+
+    print(f"{name}: {nx}x{ny}x{nz} = {numel} Hex8, {numnod} nodes")
+
+
+if __name__ == "__main__":
+    write_mesh()

--- a/benchmark_XML/level.5/tensile/tensile.xml
+++ b/benchmark_XML/level.5/tensile/tensile.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0"?>
+<!-- Uniaxial tension — J2 cubic-spline hardening verification (#49).
+
+     Quarter-symmetry bar, 0.5 × 0.5 × 5 mm.  The top face (NS1) is
+     pulled in +z by prescribed displacement; symmetry on x=0 and y=0;
+     z=0 fixed in z.  Same material as level.5/brinell/ so that any
+     downstream coupon test or pedicle-screw demo can rely on the same
+     calibrated hardening curve.
+
+     Loading: 25 quasi-static steps to δ_z = 3.25 mm = 65 % engineering
+     strain over a 5 mm half-length (true ε ≈ ln(1+0.65) ≈ 0.50,
+     matching the last spline knot at ε_p = 0.5).
+
+     Output:
+       io0.exo  — all nodes — D_X/Y/Z, Cauchy stress, J2 outputs
+                  (alpha, norm_beta, VM_Kirch, press)
+     compare_to_hardening.py extracts σ_zz vs α from the central
+     IP-column and overlays the input spline.
+-->
+<tahoe geometry_file="tensile.geom"
+       output_format="ExodusII"
+       title="tensile_J2_cubic_spline_verification">
+    <time num_steps="25" output_inc="1" time_step="0.04">
+        <schedule_function>
+            <piecewise_linear>
+                <OrderedPair x="0.0" y="0.0"/>
+                <OrderedPair x="1.0" y="1.0"/>
+            </piecewise_linear>
+        </schedule_function>
+    </time>
+    <nodes>
+        <field field_name="displacement">
+            <dof_labels>
+                <String value="D_X"/>
+                <String value="D_Y"/>
+                <String value="D_Z"/>
+            </dof_labels>
+            <!-- top: pulled in +z -->
+            <!-- Pull to 10 % engineering strain.  The hardening curve is steepest
+                 from ε_p=0 to ε_p≈0.1; past that the spline saturates and the
+                 global Newton tangent becomes near-singular for prescribed-
+                 displacement control.  10 % covers σ=250→~575 MPa, the
+                 interesting validation range. -->
+            <kinematic_BC dof="3" node_ID="1" schedule="1" type="u" value="0.5"/>
+            <!-- bottom: u_z = 0 -->
+            <kinematic_BC dof="3" node_ID="2"/>
+            <!-- symmetry -->
+            <kinematic_BC dof="1" node_ID="3"/>
+            <kinematic_BC dof="2" node_ID="4"/>
+        </field>
+    </nodes>
+    <element_list>
+        <updated_lagrangian field_name="displacement">
+            <hexahedron/>
+            <solid_element_nodal_output displacements="1" material_output="1" stress="1"/>
+            <large_strain_element_block>
+                <block_ID_list>
+                    <String value="1"/>
+                </block_ID_list>
+                <large_strain_material_3D>
+                    <Simo_J2 density="7.85">
+                        <E_and_nu Poisson_ratio="0.3" Young_modulus="200000.0"/>
+                        <cubic_spline fixity="parabolic">
+                            <!-- Denser knot set than brinell.xml so the spline is
+                                 well-behaved (monotonically hardening) across the
+                                 full strain range exercised here.  Same shape:
+                                 σ_y0 = 250, saturating ~650 MPa near ε_p = 0.5. -->
+                            <OrderedPair x="0.000" y="250.0"/>
+                            <OrderedPair x="0.005" y="320.0"/>
+                            <OrderedPair x="0.020" y="420.0"/>
+                            <OrderedPair x="0.050" y="500.0"/>
+                            <OrderedPair x="0.080" y="535.0"/>
+                            <OrderedPair x="0.110" y="560.0"/>
+                            <OrderedPair x="0.150" y="580.0"/>
+                            <OrderedPair x="0.200" y="600.0"/>
+                            <OrderedPair x="0.300" y="625.0"/>
+                            <OrderedPair x="0.400" y="640.0"/>
+                            <OrderedPair x="0.500" y="650.0"/>
+                        </cubic_spline>
+                    </Simo_J2>
+                </large_strain_material_3D>
+            </large_strain_element_block>
+        </updated_lagrangian>
+    </element_list>
+    <nonlinear_solver_LS abs_tolerance="1.0e-6"
+                         rel_tolerance="1.0e-8"
+                         divergence_tolerance="1.0e+04"
+                         max_iterations="40"
+                         search_iterations="10"
+                         orthog_tolerance="0.1"
+                         max_step_size="1.0">
+        <SPOOLES_matrix/>
+    </nonlinear_solver_LS>
+</tahoe>


### PR DESCRIPTION
## Summary
Pulls a slim quarter-symmetry bar (4 × 4 × 40 Hex8, 0.5 × 0.5 × 5 mm) in monotonic tension to verify that `<Simo_J2>` with `cubic_spline` isotropic hardening reproduces the input σ_y(ε_p) data faithfully.

Same material as `level.5/brinell/` so the two benchmarks together exercise the J2-spline path under both contact loading and pure tension.

## Result — radial-return tracks the input spline within ~2 %

Probe IP at the bar centre.  σ_xx, σ_yy ≤ 1e-5 MPa throughout → clean uniaxial state, so σ_VM = σ_zz = σ_y(α).

| t | α | σ_zz [MPa] | σ_VM [MPa] | nearest knot |
|---:|----:|-----------:|-----------:|--------------|
| 0.04 | 0.003 | 288.6 | 288.7 | (0.005, 320) |
| 0.20 | 0.018 | 410.9 | 411.3 | (0.020, 420) |
| 0.60 | 0.056 | 509.3 | 509.8 | (0.050, 500) |
| 1.00 | 0.093 | 546.0 | 546.5 | between (0.080, 535) / (0.110, 560) — linear interp = 545.8 |

|VM − σ_y(α)| / σ_y(α) ≈ 2.16 % at the last frame — well within radial-return tolerance.

## Notes

- **Why we stop at 10 % strain, not 50 %**: past α ≈ 0.10 the spline saturates and `dσ_y/dε_p` drops sharply.  With prescribed-displacement control, the global Newton tangent becomes near-singular in the axial direction and line search collapses.  Reaching the full ε_p = 0.5 range needs arc-length or load-controlled formulation — deferred as future work; documented in `tensile/README.md`.
- **Denser spline knots** than `brinell.xml` (11 vs 6) in the 0–0.5 range to avoid cubic-spline wiggle between widely-spaced knots — important for monotonic hardening and positive-definite plastic tangent.

## Test plan
- [x] All 25 steps converge with Newton-LS + SPOOLES.
- [x] σ_VM vs α overlays the input spline to ~2 %.
- [x] σ_xx, σ_yy stay at machine zero → confirms uniaxial state.
- [x] ctest unchanged (no code changes outside the benchmark dir).